### PR TITLE
[GLO3] Add `User` Model and Authentication

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,7 @@ AllCops:
   Exclude:
     - 'bin/**/*'
     - 'node_modules/**/*'
+    - 'db/schema.rb'
 
 Metrics/MethodLength:
   CountComments: false

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem "jbuilder", "~> 2.7"
 
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", ">= 1.4.2", require: false
+gem "clearance"
 
 group :development, :test do
   gem "pry-byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,6 +63,7 @@ GEM
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
+    bcrypt (3.1.13)
     bindex (0.8.1)
     bootsnap (1.4.4)
       msgpack (~> 1.0)
@@ -83,6 +84,13 @@ GEM
     childprocess (1.0.1)
       rake (< 13.0)
     choice (0.2.0)
+    clearance (1.17.0)
+      actionmailer (>= 3.1)
+      activemodel (>= 3.1)
+      activerecord (>= 3.1)
+      bcrypt
+      email_validator (~> 1.4)
+      railties (>= 3.1)
     codeclimate-engine-rb (0.4.1)
       virtus (~> 1.0)
     coderay (1.1.2)
@@ -93,6 +101,8 @@ GEM
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.3)
+    email_validator (1.6.0)
+      activemodel
     equalizer (0.0.11)
     erubi (1.8.0)
     erubis (2.7.0)
@@ -305,6 +315,7 @@ DEPENDENCIES
   brakeman
   bundler-audit
   capybara (>= 2.15)
+  clearance
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  include Clearance::Controller
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class User < ApplicationRecord
+  include Clearance::User
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,19 @@
   </head>
 
   <body>
+    <% if signed_in? %>
+      Signed in as: <%= current_user.email %>
+      <%= button_to 'Sign out', sign_out_path, method: :delete %>
+    <% else %>
+      <%= link_to 'Sign in', sign_in_path %>
+    <% end %>
+
+    <div id="flash">
+      <% flash.each do |key, value| %>
+        <div class="flash <%= key %>"><%= value %></div>
+      <% end %>
+    </div>
+
     <%= yield %>
   </body>
 </html>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,6 +38,8 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  config.action_mailer.default_url_options = { host: "localhost:3000" }
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -68,6 +68,8 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
+  config.action_mailer.default_url_options = { host: "temperature-alert.herokuapp.com" }
+
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -42,6 +42,8 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
+  config.action_mailer.default_url_options = { host: "localhost:3000" }
+
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 

--- a/config/initializers/clearance.rb
+++ b/config/initializers/clearance.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Clearance.configure do |config|
+  config.cookie_domain = "temperature-alert.herokuapp.com"
+  config.mailer_sender = "conradbeach@protonmail.com"
+  config.rotate_csrf_on_sign_in = true
+  config.secure_cookie = true
+  config.user_model = User
+end

--- a/db/migrate/20190726201409_create_users.rb
+++ b/db/migrate/20190726201409_create_users.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreateUsers < ActiveRecord::Migration[6.0]
+  def change
+    create_table :users do |t|
+      t.timestamps null: false
+      t.string :email, null: false
+      t.string :encrypted_password, limit: 128, null: false
+      t.string :confirmation_token, limit: 128
+      t.string :remember_token, limit: 128, null: false
+    end
+
+    add_index :users, :email
+    add_index :users, :remember_token
+  end
+end

--- a/db/migrate/20190726204303_add_zip_and_phone_to_users.rb
+++ b/db/migrate/20190726204303_add_zip_and_phone_to_users.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddZipAndPhoneToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :zip_code, :string
+    add_column :users, :phone_number, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_26_201409) do
+ActiveRecord::Schema.define(version: 2019_07_26_204303) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,8 @@ ActiveRecord::Schema.define(version: 2019_07_26_201409) do
     t.string "encrypted_password", limit: 128, null: false
     t.string "confirmation_token", limit: 128
     t.string "remember_token", limit: 128, null: false
+    t.string "zip_code"
+    t.string "phone_number"
     t.index ["email"], name: "index_users_on_email"
     t.index ["remember_token"], name: "index_users_on_remember_token"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,29 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2019_07_26_201409) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "users", force: :cascade do |t|
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.string "email", null: false
+    t.string "encrypted_password", limit: 128, null: false
+    t.string "confirmation_token", limit: 128
+    t.string "remember_token", limit: 128, null: false
+    t.index ["email"], name: "index_users_on_email"
+    t.index ["remember_token"], name: "index_users_on_remember_token"
+  end
+
+end


### PR DESCRIPTION
## Goal
Add a `User` model and authentication.

## Implementation
Added the Clearance gem and ran the installer. The `User` model was automatically created by the Clearance installer. I added the `zip_code` and `phone_number` attributes.

Added a rule to Rubocop to ignore the `schema.rb` file. It's automatically generated by Rails and we shouldn't be editing it, so enforcing style rules makes little sense.