### PR TITLE
Add `Alert` Model

### DIFF
--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Represents an alert created by an individual User.
+# When the temperature in a User's area hits the temperature stored in the
+# Alert, a notification is sent to the User. This notification will include the
+# Alert's message if one is given.
+class Alert < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Represents an end user of the application.
 class User < ApplicationRecord
   include Clearance::User
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,4 +2,6 @@
 
 class User < ApplicationRecord
   include Clearance::User
+
+  has_many :alerts
 end

--- a/db/migrate/20190726214850_create_alerts.rb
+++ b/db/migrate/20190726214850_create_alerts.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreateAlerts < ActiveRecord::Migration[6.0]
+  def change
+    create_table :alerts do |t|
+      t.belongs_to :user, foreign_key: false
+
+      t.integer :temperature
+      t.text :message
+
+      t.timestamps
+    end
+
+    add_foreign_key :alerts, :users, on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_26_204303) do
+ActiveRecord::Schema.define(version: 2019_07_26_214850) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "alerts", force: :cascade do |t|
+    t.bigint "user_id"
+    t.integer "temperature"
+    t.text "message"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_alerts_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
@@ -28,4 +37,5 @@ ActiveRecord::Schema.define(version: 2019_07_26_204303) do
     t.index ["remember_token"], name: "index_users_on_remember_token"
   end
 
+  add_foreign_key "alerts", "users", on_delete: :cascade
 end


### PR DESCRIPTION
Add an alert model. An `Alert` represents an alert created by an individual `User`. When the temperature in a `User`'s area hits the temperature stored in the `Alert`, a notification is sent to the `User`. This notification will include the `Alert`'s message if one is given.

`Alert` `belongs_to` `User`.