### PR TITLE
Add `Delivery` Model

### DIFF
--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -6,4 +6,5 @@
 # Alert's message if one is given.
 class Alert < ApplicationRecord
   belongs_to :user
+  has_many :deliveries
 end

--- a/app/models/delivery.rb
+++ b/app/models/delivery.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Represents the delivery of an alert to a user. As of now, alerts are
+# only sent via SMS.
+class Delivery < ApplicationRecord
+  belongs_to :alert
+end

--- a/db/migrate/20190729173624_create_deliveries.rb
+++ b/db/migrate/20190729173624_create_deliveries.rb
@@ -1,0 +1,13 @@
+class CreateDeliveries < ActiveRecord::Migration[6.0]
+  def change
+    create_table :deliveries do |t|
+      t.belongs_to :alert, foreign_key: false
+
+      t.datetime :sent_at
+
+      t.timestamps
+    end
+
+    add_foreign_key :deliveries, :alerts, on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_26_214850) do
+ActiveRecord::Schema.define(version: 2019_07_29_173624) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,14 @@ ActiveRecord::Schema.define(version: 2019_07_26_214850) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_alerts_on_user_id"
+  end
+
+  create_table "deliveries", force: :cascade do |t|
+    t.bigint "alert_id"
+    t.datetime "sent_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["alert_id"], name: "index_deliveries_on_alert_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -38,4 +46,5 @@ ActiveRecord::Schema.define(version: 2019_07_26_214850) do
   end
 
   add_foreign_key "alerts", "users", on_delete: :cascade
+  add_foreign_key "deliveries", "alerts", on_delete: :cascade
 end


### PR DESCRIPTION
A `Delivery` represents the delivery of an alert to a user. As of now, alerts are only sent via SMS.
