### PR TITLE
Add Task to Send Alerts

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,6 +32,7 @@ Metrics/LineLength:
   Description: 'Limit lines to 80 characters.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#80-character-limits'
   Max: 100
+  IgnoredPatterns: ['\A\s*#'] # Comments
   Enabled: true
 
 Style/WordArray:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,11 @@ Style/StringLiterals:
   EnforcedStyle: double_quotes
   Enabled: true
 
+Metrics/BlockLength:
+  Description: 'This cop checks if the length of a block exceeds some maximum value. Comment lines can optionally be ignored. The maximum allowed length is configurable. The cop can be configured to ignore blocks passed to certain methods.'
+  Exclude: ['spec/**/*']
+  Enabled: true
+
 Metrics/LineLength:
   Description: 'Limit lines to 80 characters.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#80-character-limits'
@@ -75,3 +80,8 @@ Layout/AlignParameters:
 Style/ClassAndModuleChildren:
   Description: This cop checks the style of children definitions at classes and modules.
   Enabled: false
+
+RSpec/ExampleLength:
+  Description: Checks for long examples. A long example is usually more difficult to understand. Consider extracting out some behaviour, e.g. with a let block, or a helper method.
+  Max: 10
+  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,7 +25,7 @@ Style/StringLiterals:
 
 Metrics/BlockLength:
   Description: 'This cop checks if the length of a block exceeds some maximum value. Comment lines can optionally be ignored. The maximum allowed length is configurable. The cop can be configured to ignore blocks passed to certain methods.'
-  Exclude: ['spec/**/*']
+  Exclude: ['spec/**/*', 'config/**/*']
   Enabled: true
 
 Metrics/LineLength:

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem "clearance"
 gem "rest-client", "~> 2.0"
 
 group :development, :test do
+  gem "factory_bot_rails", "~> 5.0"
   gem "pry-byebug"
   gem "rspec-rails", "~> 3.8"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,6 +121,11 @@ GEM
     equalizer (0.0.11)
     erubi (1.8.0)
     erubis (2.7.0)
+    factory_bot (5.0.2)
+      activesupport (>= 4.2.0)
+    factory_bot_rails (5.0.2)
+      factory_bot (~> 5.0.2)
+      railties (>= 4.2.0)
     ffi (1.11.1)
     flay (2.12.0)
       erubis (~> 2.7.0)
@@ -358,6 +363,7 @@ DEPENDENCIES
   bundler-audit
   capybara (>= 2.15)
   clearance
+  factory_bot_rails (~> 5.0)
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -7,5 +7,41 @@
 class Alert < ApplicationRecord
   belongs_to :user
   has_many :deliveries, dependent: :destroy
+
   validates :temperature_threshold, presence: true
+
+  # Delivers the alert via SMS to the owning user if the following 2 conditions are met:
+  # 1. The given `current_temperature` is greater than or equal to the `temperature_threshold` for the alert.
+  # 2. The alert hasn't already been delivered today.
+  #
+  # @param current_temperature The current temperature for the owning user's zip code.
+  #
+  # @return The newly created `Delivery` record if the alert is delivered; `nil` otherwise.
+  def conditionally_deliver(current_temperature)
+    return if current_temperature < temperature_threshold
+    return if delivered_today?
+
+    deliver
+  end
+
+  private
+
+  def delivered_today?
+    latest_sent_at_time = deliveries.order(sent_at: :desc).pick(:sent_at)
+
+    latest_sent_at_time&.today?
+  end
+
+  def deliver
+    Aws::SNS::Client.new.publish(
+      phone_number: user.phone_number,
+      message: formatted_message,
+    )
+
+    deliveries.create(sent_at: Time.current)
+  end
+
+  def formatted_message
+    "Temperature Alert: It hit #{temperature_threshold} degrees. #{message}"
+  end
 end

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -7,4 +7,5 @@
 class Alert < ApplicationRecord
   belongs_to :user
   has_many :deliveries
+  validates :temperature_threshold, presence: true
 end

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -6,6 +6,6 @@
 # Alert's message if one is given.
 class Alert < ApplicationRecord
   belongs_to :user
-  has_many :deliveries
+  has_many :deliveries, dependent: :destroy
   validates :temperature_threshold, presence: true
 end

--- a/app/models/delivery.rb
+++ b/app/models/delivery.rb
@@ -4,4 +4,6 @@
 # only sent via SMS.
 class Delivery < ApplicationRecord
   belongs_to :alert
+
+  validates :sent_at, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,5 +4,5 @@
 class User < ApplicationRecord
   include Clearance::User
 
-  has_many :alerts
+  has_many :alerts, dependent: :destroy
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,22 @@ class User < ApplicationRecord
   include Clearance::User
 
   has_many :alerts, dependent: :destroy
+
+  # Conditionally delivers all alerts for all users.
+  def self.deliver_alerts
+    current_temperatures = distinct.pluck(:zip_code).map do |zip_code|
+      [zip_code, Weather.temperature_of(zip_code)]
+    end.to_h
+
+    find_each do |user|
+      user.deliver_alerts(current_temperatures[user.zip_code])
+    end
+  end
+
+  # Conditionally delivers all alerts for the user.
+  def deliver_alerts(current_temperature)
+    alerts.each do |alert|
+      alert.conditionally_deliver(current_temperature)
+    end
+  end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,5 +19,7 @@ module TemperatureAlert
     # the framework and any gems in your application.
 
     config.autoload_paths += ["lib"]
+
+    config.time_zone = "Pacific Time (US & Canada)"
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -63,4 +63,8 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.generators do |g|
+    g.factory_bot suffix: "factory"
+  end
 end

--- a/db/migrate/20190805204512_rename_alerts_temperature_to_temperature_threshhold.rb
+++ b/db/migrate/20190805204512_rename_alerts_temperature_to_temperature_threshhold.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RenameAlertsTemperatureToTemperatureThreshhold < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :alerts, :temperature, :temperature_threshold
+  end
+end

--- a/db/migrate/20190806154905_disallow_null_temperature_threshold_for_alerts.rb
+++ b/db/migrate/20190806154905_disallow_null_temperature_threshold_for_alerts.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class DisallowNullTemperatureThresholdForAlerts < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :alerts, :temperature_threshold, false
+  end
+end

--- a/db/migrate/20190806161400_disallow_null_sent_at_for_deliveries.rb
+++ b/db/migrate/20190806161400_disallow_null_sent_at_for_deliveries.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class DisallowNullSentAtForDeliveries < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :deliveries, :sent_at, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_29_173624) do
+ActiveRecord::Schema.define(version: 2019_08_05_204512) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "alerts", force: :cascade do |t|
     t.bigint "user_id"
-    t.integer "temperature"
+    t.integer "temperature_threshold"
     t.text "message"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_06_154905) do
+ActiveRecord::Schema.define(version: 2019_08_06_161400) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,7 +26,7 @@ ActiveRecord::Schema.define(version: 2019_08_06_154905) do
 
   create_table "deliveries", force: :cascade do |t|
     t.bigint "alert_id"
-    t.datetime "sent_at"
+    t.datetime "sent_at", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["alert_id"], name: "index_deliveries_on_alert_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_05_204512) do
+ActiveRecord::Schema.define(version: 2019_08_06_154905) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "alerts", force: :cascade do |t|
     t.bigint "user_id"
-    t.integer "temperature_threshold"
+    t.integer "temperature_threshold", null: false
     t.text "message"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/lib/tasks/alerts.rake
+++ b/lib/tasks/alerts.rake
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+namespace :alerts do
+  desc "Conditionally delivers alerts via SMS. This task is called by Heroku scheduler."
+  task :deliver do
+    User.deliver_alerts
+  end
+end

--- a/spec/factories/alerts_factory.rb
+++ b/spec/factories/alerts_factory.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :alert do
+    temperature_threshold { (50..100).to_a.sample }
+
+    user
+  end
+end

--- a/spec/factories/deliveries_factory.rb
+++ b/spec/factories/deliveries_factory.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :delivery do
+    sent_at { Time.current }
+
+    alert
+  end
+end

--- a/spec/factories/users_factory.rb
+++ b/spec/factories/users_factory.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :user do
+    sequence(:email) { |n| "user_#{n}@example.com" }
+    password { "password" }
+    zip_code { "00601" }
+    phone_number { "+15552529832" }
+  end
+end

--- a/spec/models/alert_spec.rb
+++ b/spec/models/alert_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Alert, type: :model do
+  let!(:sns_client_double) { instance_double(Aws::SNS::Client) }
+
+  before do
+    allow(Aws::SNS::Client).to receive(:new).and_return(sns_client_double)
+    allow(sns_client_double).to receive(:publish)
+  end
+
+  describe "#conditionally_deliver" do
+    let!(:alert) { create(:alert) }
+
+    context "when conditions are met" do
+      it "delivers the alert" do
+        alert.conditionally_deliver(alert.temperature_threshold + 5)
+
+        expect(sns_client_double).to have_received(:publish)
+          .with(
+            phone_number: alert.user.phone_number,
+            message: /Temperature Alert/,
+          )
+      end
+
+      it "creates a new Delivery record" do
+        expect do
+          alert.conditionally_deliver(alert.temperature_threshold + 5)
+        end.to change { alert.deliveries.size }.from(0).to(1)
+      end
+
+      it "gives the Delivery the correct sent_at time" do
+        alert.conditionally_deliver(alert.temperature_threshold + 5)
+
+        expect(alert.deliveries.last.sent_at).to be_within(5).of(Time.current)
+      end
+    end
+
+    context "when the current temperature equals the temperature_threshold" do
+      it "delivers the alert" do
+        alert.conditionally_deliver(alert.temperature_threshold)
+
+        expect(sns_client_double).to have_received(:publish)
+          .with(
+            phone_number: alert.user.phone_number,
+            message: /Temperature Alert/,
+          )
+      end
+    end
+
+    context "when the alert has a custom message" do
+      let(:custom_message) { "Extra info..." }
+      let!(:alert) { create(:alert, message: custom_message) }
+
+      it "includes the custom message in the message sent to the user" do
+        alert.conditionally_deliver(alert.temperature_threshold + 5)
+
+        expect(sns_client_double).to have_received(:publish)
+          .with(
+            phone_number: alert.user.phone_number,
+            message: /#{custom_message}/,
+          )
+      end
+    end
+
+    context "when the current temperature is lower than the temperature threshold" do
+      it "does not deliver the alert" do
+        alert.conditionally_deliver(alert.temperature_threshold - 5)
+
+        expect(sns_client_double).not_to have_received(:publish)
+      end
+    end
+
+    context "when the alert has already been delivered today" do
+      it "does not deliver the alert" do
+        create(:delivery, alert: alert, sent_at: Time.current)
+
+        alert.conditionally_deliver(alert.temperature_threshold + 5)
+
+        expect(sns_client_double).not_to have_received(:publish)
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -60,4 +60,6 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.include FactoryBot::Syntax::Methods
 end


### PR DESCRIPTION
## Goal
Add a rake task to deliver alerts. This rake task will be called by the Heroku Scheduler every 10 minutes.

## Implementation
The logic for delivering alerts lives in the `Alert` model. A couple of methods were added to the `User` model that handle iterating through each `User` and each `User`'s `Alert`s and conditionally delivering each `Alert`.

`Alert`s are delivered via SMS to the owning user if the following 2 conditions are met:
1. The current temperature of the owning `User`'s zip code is greater than or equal to the `temperature_threshold` for the alert.
2. The alert hasn't already been delivered that day.

This pull request includes a few other small things such as adding a couple of validations for the `Alert` and `Delivery` models along with improving some Rubocop cops.

The `factory_bot_rails` gem was also added to improve testing.

## Tradeoffs & Alternatives
It's important to note that the new methods on the `User` model are untested. They're fairly simple, but they're complex enough that I would certainly test them under normal conditions. I didn't add any tests for these methods because I couldn't figure out an effective way to test them. This definitely should be revisited. The current implementation probably just needs to be refactored to make it testable.