### PR TITLE
Fix Webmock Issue

### DIFF
--- a/spec/lib/weather_spec.rb
+++ b/spec/lib/weather_spec.rb
@@ -4,8 +4,17 @@ require "rails_helper"
 
 RSpec.describe Weather, type: :module do
   describe ".temperature_of" do
+    before do
+      WebMock.stub_request(:get, %r{https://api.darksky.net/forecast/\w+/18.180555,-66.749961})
+        .to_return(
+          status: 200,
+          body: File.read(
+            File.join("spec", "fixtures", "dark_sky_puerto_rico_response.json"),
+          ),
+        )
+    end
+
     it "returns the current temperature of the given zip code" do
-      # The underlying request is mocked in spec/support/webmock.rb
       expect(described_class.temperature_of("00601")).to eq(77)
     end
 

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-WebMock.stub_request(:get, %r{https://api.darksky.net/forecast/\w+/18.180555,-66.749961})
-  .to_return(
-    status: 200,
-    body: File.read(
-      File.join("spec", "fixtures", "dark_sky_puerto_rico_response.json"),
-    ),
-  )


### PR DESCRIPTION
We ran into an issue where a request wasn't getting stubbed properly about half the time depending on what order you ran the specs in. When it wasn't stubbed properly, one of the specs in the `weather_spec.rb` file would fail because it attempted to make a real HTTP request.

I'm assuming it has something to do with how we were mocking the request in the support file. If you ran only the `weather_spec.rb` file, the spec would pass every time. If another spec file was loaded and executed before the `weather_spec.rb` file, the spec in the `weather_spec.rb` file would fail every time.

I didn't figure exactly what the problem was. I ultimately decided to move the Webmock stub from the support file into the `weather_spec.rb` file. This fixed the issue, and it also has the advantage of making it easier to understand the specs. I wish I would have figured out what was going on, but I like this solution well enough.