### PR TITLE
Automatically Migrate Database on Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
+release: rails db:migrate
 web: bundle exec puma -t 5:5 -p ${PORT:-3000} -e ${RACK_ENV:-development}


### PR DESCRIPTION
Adding this `release` command will automatically migrate the database during the Heroku release phase so we don't need to do it manually.

More info can be found [here](https://devcenter.heroku.com/articles/release-phase).
