### PR TITLE
Fix alerts:deliver Rake Task

### DIFF
--- a/lib/tasks/alerts.rake
+++ b/lib/tasks/alerts.rake
@@ -2,7 +2,7 @@
 
 namespace :alerts do
   desc "Conditionally delivers alerts via SMS. This task is called by Heroku scheduler."
-  task :deliver do
+  task deliver: :environment do
     User.deliver_alerts
   end
 end


### PR DESCRIPTION
I didn't load the environment in the alerts:deliver task, so it's completely broken. :facepalm:

This should fix things up. We won't talk about how I failed to even try running the task directly and only tested running the code it executes.
