### PR TITLE
Add Tools to Document API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ group :development, :test do
   gem "factory_bot_rails", "~> 5.0"
   gem "pry-byebug"
   gem "rspec-rails", "~> 3.8"
+  gem "rspec_api_documentation", "~> 6.0"
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ ruby "2.6.3"
 
 gem "rails", "~> 6.0.0.rc2"
 
+gem "apitome", "~> 0.3.0"
 gem "aws-sdk-sns", "~> 1"
 gem "bootsnap", ">= 1.4.2", require: false
 gem "fast_jsonapi", "~> 1.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,6 +150,7 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.11.3)
     msgpack (1.3.0)
+    mustache (1.1.0)
     netrc (0.11.0)
     nio4r (2.4.0)
     nokogiri (1.10.3)
@@ -212,6 +213,10 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
     rspec-core (3.8.2)
       rspec-support (~> 3.8.0)
     rspec-expectations (3.8.4)
@@ -229,6 +234,10 @@ GEM
       rspec-mocks (~> 3.8.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.2)
+    rspec_api_documentation (6.1.0)
+      activesupport (>= 3.0.0)
+      mustache (~> 1.0, >= 0.99.4)
+      rspec (~> 3.0)
     rubocop (0.70.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
@@ -312,6 +321,7 @@ DEPENDENCIES
   rails (~> 6.0.0.rc2)
   rest-client (~> 2.0)
   rspec-rails (~> 3.8)
+  rspec_api_documentation (~> 6.0)
   rubocop
   rubocop-performance
   rubocop-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,9 @@ GEM
       zeitwerk (~> 2.1, >= 2.1.8)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
+    apitome (0.3.0)
+      kramdown
+      railties
     ast (2.4.0)
     aws-eventstream (1.0.3)
     aws-partitions (1.194.0)
@@ -127,6 +130,7 @@ GEM
     ice_nine (0.11.2)
     jaro_winkler (1.5.2)
     jmespath (1.4.0)
+    kramdown (2.1.0)
     kwalify (0.7.2)
     launchy (2.4.3)
       addressable (~> 2.3)
@@ -308,6 +312,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  apitome (~> 0.3.0)
   aws-sdk-sns (~> 1)
   bootsnap (>= 1.4.2)
   brakeman

--- a/config/initializers/apitome.rb
+++ b/config/initializers/apitome.rb
@@ -1,0 +1,66 @@
+Apitome.configure do |config|
+  # This determines where the Apitome routes will be mounted. Changing this to "/api/documentation" for instance would
+  # allow you to browse to http://localhost:3000/api/documentation to see your api documentation. Set to nil and mount
+  # it yourself if you need to.
+  config.mount_at = "/api/docs"
+
+  # This defaults to Rails.root if left nil. If you're providing documentation for an engine using a dummy application
+  # it can be useful to set this to your engines root.. E.g. `Application::Engine.root`
+  config.root = nil
+
+  # This is where rspec_api_documentation outputs the JSON files. This is configurable within RAD, and so is
+  # configurable here.
+  config.doc_path = "doc/api"
+
+  # Set the parent controller that Apitome::DocsController will inherit from. Useful if you want to use a custom
+  # `before_action` for instance.
+  config.parent_controller = "ActionController::Base"
+
+  # The title of the documentation -- If your project has a name, you'll want to put it here.
+  config.title = "Apitome Documentation"
+
+  # The main layout view for all documentation pages. By default this is pretty basic, but you may want to use your own
+  # application layout.
+  config.layout = "apitome/application"
+
+  # We're using highlight.js (https://github.com/isagalaev/highlight.js) for code highlighting, and it comes with some
+  # great themes. You can check [here for themes](http://softwaremaniacs.org/media/soft/highlight/test.html), and enter
+  # the theme as lowercase/underscore.
+  config.code_theme = "default"
+
+  # This allows you to override the css manually. You typically want to require `apitome/application` within the
+  # override, but if you want to override it entirely you can do so.
+  config.css_override = nil
+
+  # This allows you to override the javascript manually. You typically want to require `apitome/application` within the
+  # override, but if you want to override it entirely you can do so.
+  config.js_override = nil
+
+  # You can provide a "README" style markdown file for the documentation, which is a useful place to include general
+  # information. This path is relative to your doc_path configuration.
+  config.readme = "../api.md"
+
+  # Apitome can render the documentation into a single page that uses scrollspy, or it can render the documentation on
+  # individual pages on demand. This allows you to specify which one you want, as a single page may impact performance.
+  config.single_page = true
+
+  # You can specify how urls are formatted using a Proc or other callable object.  Your proc will be called with a
+  # resource name or link, giving you the opportunity to modify it as necessary for in the documentation url.
+  config.url_formatter = -> (str) { str.gsub(/\.json$/, '').underscore.gsub(/[^0-9a-z\:]+/i, '-') }
+
+  # You can setup the docs to be loaded from a remote URL if they are not available in the application environment. This
+  # URL is used as the base location and should be set to where the readme is located. If left nil, local is assumed.
+  config.remote_url = nil
+
+  # If the remote_docs is set to true, and the remote URL is protected by
+  # HTTP Basic Authentication you can set the user and password here as an array.
+  # Usage: `http_basic_authentication = ['user', 'password']`.
+  # This defaults to nil.
+  config.http_basic_authentication = nil
+
+  # If you would like to precompile your own assets, you can disable auto-compilation.
+  config.precompile_assets = true
+
+  # If you do not want "Simulated Response" links to appear you can disable them.
+  config.simulated_response = true
+end

--- a/config/initializers/apitome.rb
+++ b/config/initializers/apitome.rb
@@ -19,7 +19,7 @@ Apitome.configure do |config|
   config.parent_controller = "ActionController::Base"
 
   # The title of the documentation -- If your project has a name, you'll want to put it here.
-  config.title = "Apitome Documentation"
+  config.title = "Temperature Alert API Documentation"
 
   # The main layout view for all documentation pages. By default this is pretty basic, but you may want to use your own
   # application layout.

--- a/config/initializers/apitome.rb
+++ b/config/initializers/apitome.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Apitome.configure do |config|
   # This determines where the Apitome routes will be mounted. Changing this to "/api/documentation" for instance would
   # allow you to browse to http://localhost:3000/api/documentation to see your api documentation. Set to nil and mount
@@ -46,7 +48,7 @@ Apitome.configure do |config|
 
   # You can specify how urls are formatted using a Proc or other callable object.  Your proc will be called with a
   # resource name or link, giving you the opportunity to modify it as necessary for in the documentation url.
-  config.url_formatter = -> (str) { str.gsub(/\.json$/, '').underscore.gsub(/[^0-9a-z\:]+/i, '-') }
+  config.url_formatter = ->(str) { str.gsub(/\.json$/, "").underscore.gsub(/[^0-9a-z\:]+/i, "-") }
 
   # You can setup the docs to be loaded from a remote URL if they are not available in the application environment. This
   # URL is used as the base location and should be set to where the readme is located. If left nil, local is assumed.

--- a/doc/api.md
+++ b/doc/api.md
@@ -1,0 +1,4 @@
+Apitome Documentation
+=====================
+
+This file was automatically generated, and can be found at `doc/api.md`.

--- a/doc/api.md
+++ b/doc/api.md
@@ -1,4 +1,4 @@
-Apitome Documentation
+API Documentation
 =====================
 
-This file was automatically generated, and can be found at `doc/api.md`.
+General API documentation to be added later.

--- a/doc/api/index.json
+++ b/doc/api/index.json
@@ -1,0 +1,17 @@
+{
+  "resources": [
+    {
+      "name": "Users",
+      "explanation": null,
+      "examples": [
+        {
+          "description": "Listing users",
+          "link": "users/listing_users.json",
+          "groups": "all",
+          "route": "/user",
+          "method": "get"
+        }
+      ]
+    }
+  ]
+}

--- a/doc/api/users/listing_users.json
+++ b/doc/api/users/listing_users.json
@@ -1,0 +1,17 @@
+{
+  "resource": "Users",
+  "resource_explanation": null,
+  "http_method": "GET",
+  "route": "/user",
+  "description": "Listing users",
+  "explanation": null,
+  "parameters": [
+
+  ],
+  "response_fields": [
+
+  ],
+  "requests": [
+
+  ]
+}

--- a/spec/acceptance/users_spec.rb
+++ b/spec/acceptance/users_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "rspec_api_documentation/dsl"
+
+RSpec.resource "Users" do
+  get "/user" do
+    example "Listing users" do
+      value = 10
+
+      expect(value).to be 10
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,3 +63,7 @@ RSpec.configure do |config|
 
   config.include FactoryBot::Syntax::Methods
 end
+
+RspecApiDocumentation.configure do |config|
+  config.format = :json
+end


### PR DESCRIPTION
## Goal
Add tools to document the API.

## Implementation
This adds the rspec_api_documentation gem for documenting the API. rspec_api_documentation provides a DSL for testing endpoints and generating realistic documentation based on those tests.

Apitome is a formatter for rspec_api_documentation. The default output from rspec_api_documentation is really basic. Apitome makes it a lot prettier and easier to use.